### PR TITLE
Db/make cmake v4 bug fix

### DIFF
--- a/Tests/ExporterTestsV4.cs
+++ b/Tests/ExporterTestsV4.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Xunit;
+using libEDSsharp;
+
+namespace Tests
+{
+    public class ExporterTestsV4 : CanOpenNodeExporter_V4
+    {
+        [Fact]
+        public void Test_cname_conversion()
+        {
+
+            if (Make_cname("axle 0 wheel right controlword") != "axle0WheelRightControlword")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("mapped object 4") != "mappedObject4")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("COB ID used by RPDO") != "COB_IDUsedByRPDO")
+                throw (new Exception("Make_cname Conversion error"));
+
+        }
+    }
+}

--- a/Tests/ExporterTestsV4.cs
+++ b/Tests/ExporterTestsV4.cs
@@ -19,6 +19,8 @@ namespace Tests
             if (Make_cname("COB ID used by RPDO") != "COB_IDUsedByRPDO")
                 throw (new Exception("Make_cname Conversion error"));
 
+            if (Make_cname("A/D unit offset value (filtered)") != "A_DUnitOffsetValueFiltered")
+                throw (new Exception("make_cname Conversion error"));
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="ExporterTests.cs" />
     <Compile Include="PDOHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ExporterTestsV4.cs" />
     <Compile Include="XDDImportExportTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/libEDSsharp/CanOpenNodeExporter_V4.cs
+++ b/libEDSsharp/CanOpenNodeExporter_V4.cs
@@ -664,7 +664,7 @@ OD_t *{0} = &_{0};", odname, string.Join(",\n    ", ODList)));
         /// </summary>
         /// <param name="name">string, name to convert</param>
         /// <returns>string</returns>
-        private static string Make_cname(string name)
+        protected static string Make_cname(string name)
         {
             if (name == null || name == "")
                 return "";


### PR DESCRIPTION
Fixed a bug where CanOpenNodeExporter_V4::Make_cname would not properly modify an unacceptable string and would throw an out-of-bounds exception when modifying and array. Added a test file for CanOpenNodeExporter_V4 to test my code changes and since the only tests are for CanOpenNodeExporter, not the V4 version. 

<img width="210" alt="Exception" src="https://user-images.githubusercontent.com/87715493/126498162-8f13ba3b-07c9-4dd6-9ec2-6e8e9af16738.PNG">
