### PR TITLE
Db/make cmake v4 bug

### DIFF
--- a/Tests/ExporterTestsV4.cs
+++ b/Tests/ExporterTestsV4.cs
@@ -7,9 +7,8 @@ namespace Tests
     public class ExporterTestsV4 : CanOpenNodeExporter_V4
     {
         [Fact]
-        public void Test_cname_conversion()
+        public void Test_Make_cname_conversion()
         {
-
             if (Make_cname("axle 0 wheel right controlword") != "axle0WheelRightControlword")
                 throw (new Exception("Make_cname Conversion error"));
 
@@ -17,6 +16,18 @@ namespace Tests
                 throw (new Exception("Make_cname Conversion error"));
 
             if (Make_cname("COB ID used by RPDO") != "COB_IDUsedByRPDO")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("A/D unit offset value (filtered)") != "A_DUnitOffsetValueFiltered")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("80 test string") != "_80TestString")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("Eighty test string") != "eightyTestString")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("A") != "a")
                 throw (new Exception("Make_cname Conversion error"));
 
         }

--- a/Tests/ExporterTestsV4.cs
+++ b/Tests/ExporterTestsV4.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Xunit;
+using libEDSsharp;
+
+namespace Tests
+{
+    public class ExporterTestsV4 : CanOpenNodeExporter_V4
+    {
+        [Fact]
+        public void Test_cname_conversion()
+        {
+
+            if (Make_cname("axle 0 wheel right controlword") != "axle0WheelRightControlword")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("mapped object 4") != "mappedObject4")
+                throw (new Exception("Make_cname Conversion error"));
+
+            if (Make_cname("COB ID used by RPDO") != "COB_IDUsedByRPDO")
+                throw (new Exception("Make_cname Conversion error"));
+
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="ExporterTests.cs" />
     <Compile Include="PDOHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ExporterTestsV4.cs" />
     <Compile Include="XDDImportExportTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/libEDSsharp/CanOpenNodeExporter_V4.cs
+++ b/libEDSsharp/CanOpenNodeExporter_V4.cs
@@ -664,7 +664,7 @@ OD_t *{0} = &_{0};", odname, string.Join(",\n    ", ODList)));
         /// </summary>
         /// <param name="name">string, name to convert</param>
         /// <returns>string</returns>
-        private static string Make_cname(string name)
+        protected static string Make_cname(string name)
         {
             if (name == null || name == "")
                 return "";

--- a/libEDSsharp/CanOpenNodeExporter_V4.cs
+++ b/libEDSsharp/CanOpenNodeExporter_V4.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.IO;
+using System.Linq;
 
 namespace libEDSsharp
 {
@@ -669,40 +670,50 @@ OD_t *{0} = &_{0};", odname, string.Join(",\n    ", ODList)));
             if (name == null || name == "")
                 return "";
 
-            // split string to tokens, separated by non-word characters
-            string[] tokens = Regex.Split(name.Replace('-', '_'), @"[\W]+");
+            // split string to tokens, separated by non-word characters. Remove any empty strings
+            var tokens = Regex.Split(name.Replace('-', '_'), @"[\W]+").Where(s => s != String.Empty);
 
             string output = "";
             char prev = ' ';
             foreach (string tok in tokens)
             {
-                if (tok.Length == 0)
-                    continue;
-
                 char first = tok[0];
 
-                if (Char.IsDigit(first) || Char.IsDigit(prev) || (Char.IsUpper(prev) && Char.IsUpper(first)))
+                if (Char.IsUpper(prev) && Char.IsUpper(first))
                 {
-                    // add underscore, if tok starts with digit or we have two upper-case words
-                    output += "_" + tok;
+                    // add underscore, if we have two upper-case words
+                    output += "_";
                 }
-                else if (output.Length > 0)
+
+                if (tok.Length > 1 && Char.IsLetter(first))
                 {
-                    // all tokens except the first start with uppercse letter
+                    // all tokens except the first start with uppercase letter
                     output += Char.ToUpper(first) + tok.Substring(1);
-                }
-                else if (Char.IsLower(tok[1]))
-                {
-                    // first token start with lower-case letter, except whole word is uppercase
-                    output += Char.ToLower(first) + tok.Substring(1);
                 }
                 else
                 {
-                    // use token as is
+                    // use token as is and handle what the start of the output looks like outside of the loop 
                     output += tok;
                 }
 
                 prev = tok[tok.Length - 1];
+            }
+
+            if (Char.IsDigit(output[0]))
+            {
+                // output that starts with a digit needs a starting underscore 
+                output = "_" + output;
+            }
+            else if (output.Length > 1)
+            {
+                // output that doesnt start with all-cap-words should have word start with a lower case character
+                if (Char.IsLetter(output[0]) && Char.IsLower(output[1]))
+                    output = Char.ToLower(output[0]) + output.Substring(1);
+            }
+            else
+            {
+                // single character output
+                output = output.ToLower();
             }
 
             return output;


### PR DESCRIPTION
Fixed a bug in Make_cname where an out-of-bounds of array exception was being thrown. I solved this by removing white space that was added to a split string.

Also the new method in CanOpenNodeExporter_V4 failed the tests for this function that passed in the old method in file CanOpenNodeExporter. So I reverted back to some of the old code but keep the new conditions for digits.

<img width="210" alt="Exception" src="https://user-images.githubusercontent.com/87715493/126515492-bca194b9-79f8-4e0d-a4e6-38443055d49b.PNG">
